### PR TITLE
Some fixes for compiling in MinGW

### DIFF
--- a/scripts/grab_deps_mw32.sh
+++ b/scripts/grab_deps_mw32.sh
@@ -51,6 +51,7 @@ main(){
 	triplet_install "dlfcn";
 	triplet_install "boost";
 	triplet_install "sqlite3";
+	triplet_install "cyrus-sasl";
 
 	# Install other deps
 	[[ ! -d "cvmlib_src32/" ]] && mkdir cvmlib_src32;

--- a/scripts/grab_deps_mw64.sh
+++ b/scripts/grab_deps_mw64.sh
@@ -51,6 +51,7 @@ main(){
 	triplet_install "dlfcn";
 	triplet_install "boost";
 	triplet_install "sqlite3";
+	triplet_install "cyrus_sasl";
 
 	# Install other deps
 	[[ ! -d "cvmlib_src/" ]] && mkdir cvmlib_src;

--- a/src/Sockets/LocalSocketClient-Win.hpp
+++ b/src/Sockets/LocalSocketClient-Win.hpp
@@ -51,7 +51,7 @@ protected:
 private:
 	void ConnectCallback(const boost::system::error_code& ec, std::shared_ptr<SocketCtx> ctx)
 	{
-		if (ctx->IsStopped)
+		if (ctx->IsStopped())
 			return;
 
 		if (ec)


### PR DESCRIPTION
This fixes the sasl/sasl.h not found error and the type conversion error encountered when compiling collab-vm-server on MinGW.