### PR TITLE
Minor changes to PluginManager.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ project(collab-vm-server)
 include(cmake/CollabVM.cmake)
 
 set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20")
 
 # Dependencies
 find_package(Boost REQUIRED COMPONENTS system filesystem program_options)

--- a/doc/collab-vm-server.1
+++ b/doc/collab-vm-server.1
@@ -31,6 +31,6 @@ Report bugs to the computernewb/collab-vm-server repository on GitHub. <https://
 .PP
 If you have obtained \fBcollab-vm-server\fR from another repository, please ask a repository maintainer about bug reporting.
 .SH COPYRIGHT
-Copyright \(co 2015-2021 Computernewb
+Copyright \(co 2015-2022 Computernewb
 .br
-Licensed under Apache License 2.0 <http://www.apache.org/licenses/LICENSE-2.0>.
+Licensed under the GNU General Public License 3.0 <https://www.gnu.org/licenses/gpl-3.0.en.html>.

--- a/doc/collab-vm-server.1
+++ b/doc/collab-vm-server.1
@@ -33,4 +33,4 @@ If you have obtained \fBcollab-vm-server\fR from another repository, please ask 
 .SH COPYRIGHT
 Copyright \(co 2015-2022 Computernewb
 .br
-Licensed under the GNU General Public License 3.0 <https://www.gnu.org/licenses/gpl-3.0.en.html>.
+Licensed under Apache License 2.0 <http://www.apache.org/licenses/LICENSE-2.0>.

--- a/src/core/PluginManager.cpp
+++ b/src/core/PluginManager.cpp
@@ -2,7 +2,7 @@
 #include <core/PluginManager.h>
 #include <boost/dll.hpp>
 
-#if __cplusplus >= 202002L
+#if __cplusplus <= 202002L
 #include <cstdarg>
 #endif
 
@@ -150,6 +150,8 @@ namespace collabvm::core {
 
 				return res;
 			}
+			// FIXME: This is a fallback return to prevent compile time warnings from occurring.
+			return res;
 
 		}
 

--- a/src/core/PluginManager.cpp
+++ b/src/core/PluginManager.cpp
@@ -138,18 +138,19 @@ namespace collabvm::core {
 					case PluginLoadError::NotServerPlugin: {
 						// Try loading as a coreplugin next
 						return HandlePluginLoad<true, false>(so);
-					}; break;
-
+						break;
+					}
+					
 					case PluginLoadError::NotCorePlugin: {
 						// Try loading as a controllerplugin.
 						return HandlePluginLoad<false, true>(so);
-					}; break;
+						break;
+					}
 				}
 
 				return res;
 			}
 
-			return res;
 		}
 
 		bool PluginManager::Init() {

--- a/src/core/PluginManager.cpp
+++ b/src/core/PluginManager.cpp
@@ -2,7 +2,7 @@
 #include <core/PluginManager.h>
 #include <boost/dll.hpp>
 
-#if __cplusplus <= 202002L
+#if __cplusplus < 202002L
 #include <cstdarg>
 #endif
 

--- a/src/core/PluginManager.cpp
+++ b/src/core/PluginManager.cpp
@@ -160,7 +160,7 @@ namespace collabvm::core {
 				try {
 					std::filesystem::create_directory(std::filesystem::current_path() / "plugins");
 				}
-				catch (...) {
+				catch (const std::exception&) {
 					spdlog::error("PluginManager::Init: Unable to create plugins folder!");
 					return false;
 				}

--- a/src/core/PluginManager.cpp
+++ b/src/core/PluginManager.cpp
@@ -1,7 +1,10 @@
 
 #include <core/PluginManager.h>
 #include <boost/dll.hpp>
-#include <stdarg.h>
+
+#if __cplusplus >= 202002L
+#include <cstdarg>
+#endif
 
 // TODO: Should find a better place to include this
 #define SPDLOG_FMT_EXTERNAL // why do I need to define this lol


### PR DESCRIPTION
I fixed some compiler errors on GCC 10.2 and added  handling for when the plugins folder is unable to be created.